### PR TITLE
Fix for addition of folders on Windows

### DIFF
--- a/src/Chumper/Zipper/Zipper.php
+++ b/src/Chumper/Zipper/Zipper.php
@@ -360,7 +360,7 @@ class Zipper
         // Now let's visit the subdirectories and add them, too.
         foreach ($this->file->directories($pathToDir) as $dir) {
             $old_folder = $this->currentFolder;
-            $this->currentFolder = $this->currentFolder . '/' . basename($dir);
+            $this->currentFolder = empty($this->currentFolder) ? basename($dir) : $this->currentFolder . '/' . basename($dir);
             $this->addDir($pathToDir . '/' . basename($dir));
             $this->currentFolder = $old_folder;
         }


### PR DESCRIPTION
On Windows adding folders with local file name that begins with a '/' causes issues when attempting to open the zip file on Windows. This addresses issue #33.
